### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "webpack.config.js",
   "dependencies": {
     "@types/pixi.js": "^4.8.6",
-    "npm": "^6.8.0",
     "pixi.js": "^4.8.5",
     "ts-loader": "^5.3.3",
     "typescript": "^3.2.2",


### PR DESCRIPTION

Hello developer-honcharenko!

It seems like you have npm as one of your (dev-) dependency in Pixi-Game.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
